### PR TITLE
add sf.firehose.v2 with better steps management

### DIFF
--- a/sf/firehose/v2/firehose.proto
+++ b/sf/firehose/v2/firehose.proto
@@ -1,0 +1,92 @@
+syntax = "proto3";
+
+package sf.firehose.v2;
+
+import "google/protobuf/any.proto";
+
+option go_package = "github.com/streamingfast/pbgo/sf/firehose/v2;pbfirehose";
+
+service Stream {
+  rpc Blocks(Request) returns (stream Response);
+}
+
+message Request {
+
+  // Controls where the stream of blocks will start.
+  //
+  // The stream will start **inclusively** at the requested block num.
+  //
+  // When not provided, starts at first streamable block of the chain. Not all
+  // chain starts at the same block number, so you might get an higher block than
+  // requested when using default value of 0.
+  //
+  // Can be negative, will be resolved relative to the chain head block, assuming
+  // a chain at head block #100, then using `-50` as the value will start at block
+  // #50. If it resolves before first streamable block of chain, we assume start
+  // of chain.
+  //
+  // If `start_cursor` is given, this value is ignored and the stream instead starts
+  // immediately after the Block pointed by the opaque `start_cursor` value.
+  int64 start_block_num = 1;
+
+  // Controls where the stream of blocks will start which will be immediately after
+  // the Block pointed by this opaque cursor.
+  //
+  // Obtain this value from a previously received `Response.cursor`.
+  //
+  // This value takes precedence over `start_block_num`.
+  string cursor = 2;
+
+  // When non-zero, controls where the stream of blocks will stop.
+  //
+  // The stream will close **after** that block has passed so the boundary is
+  // **inclusive**.
+  uint64 stop_block_num = 3;
+
+  // no_block_finality and no_reorg_finality result in the following matrix:
+  //
+  // NO_REORG  NO_FINALITY     Received steps (example stream)
+  // 0         0               NEW_IRR NEW_IRR NEW UNDO NEW NEW IRR IRR NEW
+  // 1         0               IRR IRR IRR IRR IRR IRR IRR
+  // 0         1               NEW UNDO NEW UNDO NEW NEW
+  // 1         1               NEW NEW NEW NEW NEW
+
+  // do not send any kind of irreversibility step
+  bool no_block_finality  = 4;
+
+  // do not send any undo step
+  bool no_reorg_navigation  = 5;
+
+  repeated google.protobuf.Any transforms = 10;
+}
+
+message Response {
+  // Chain specific block payload, ex:
+  //   - sf.eosio.type.v1.Block
+  //   - sf.ethereum.type.v1.Block
+  //   - sf.near.type.v1.Block
+  google.protobuf.Any block = 1;
+  ForkStep step = 6;
+  string cursor = 10;
+}
+
+enum ForkStep {
+  STEP_UNSET = 0;
+
+  // Block is new head block of the chain, that is linear with the previous
+  // block
+  STEP_NEW = 1;
+
+  // Block is now forked and should be undone, it's not the head block of
+  // the chain anymore
+  STEP_UNDO = 2;
+
+  // Block is now irreversible and can be committed (finality is chain specific,
+  // see chain documentation for more details)
+  STEP_IRREVERSIBLE = 3;
+
+  // Block is new head block of the chain, linear with the previous block,
+  // AND we already know that is irreversible, so
+  // we won't send you an extraneous STEP_IRREVERSIBLE for it
+  STEP_NEW_IRREVERSIBLE = 4;
+}

--- a/sf/firehose/v2/firehose.proto
+++ b/sf/firehose/v2/firehose.proto
@@ -43,19 +43,9 @@ message Request {
   // **inclusive**.
   uint64 stop_block_num = 3;
 
-  // no_block_finality and no_reorg_finality result in the following matrix:
-  //
-  // NO_REORG  NO_FINALITY     Received steps (example stream)
-  // 0         0               NEW_IRR NEW_IRR NEW UNDO NEW NEW IRR IRR NEW
-  // 1         0               IRR IRR IRR IRR IRR IRR IRR
-  // 0         1               NEW UNDO NEW UNDO NEW NEW
-  // 1         1               NEW NEW NEW NEW NEW
-
-  // do not send any kind of irreversibility step
-  bool no_block_finality  = 4;
-
-  // do not send any undo step
-  bool no_reorg_navigation  = 5;
+  // With final_block_only, you only receive blocks with STEP_FINAL
+  // Default behavior will send blocks as STEP_NEW, with occasional STEP_UNDO
+  bool final_blocks_only = 4;
 
   repeated google.protobuf.Any transforms = 10;
 }
@@ -73,20 +63,13 @@ message Response {
 enum ForkStep {
   STEP_UNSET = 0;
 
-  // Block is new head block of the chain, that is linear with the previous
-  // block
+  // Incoming block
   STEP_NEW = 1;
 
-  // Block is now forked and should be undone, it's not the head block of
-  // the chain anymore
+  // A reorg caused this specific block to be excluded from the chain
   STEP_UNDO = 2;
 
-  // Block is now irreversible and can be committed (finality is chain specific,
+  // Block is now final and can be committed (finality is chain specific,
   // see chain documentation for more details)
-  STEP_IRREVERSIBLE = 3;
-
-  // Block is new head block of the chain, linear with the previous block,
-  // AND we already know that is irreversible, so
-  // we won't send you an extraneous STEP_IRREVERSIBLE for it
-  STEP_NEW_IRREVERSIBLE = 4;
+  STEP_FINAL = 3;
 }


### PR DESCRIPTION
breaking changes in v2 over v1:

* step_types filter replaced with 2 bools to represent 4 possible operational modes:
``` 
   no_block_finality  // do not send any kind of irreversibility step
   no_reorg_navigation    // do not send any undo step
```
* Add STEP_NEW_IRREVERSIBLE to StepType enum, to allow saving 50% bandwidth on reproc
* Since we are moving to v2, we remove deprecated fields and renumber